### PR TITLE
chore: receipt-api to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.118
 - name: receipt-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9


### PR DESCRIPTION
chore: Promote receipt-api to version 0.0.9