### PR TITLE
chore: receipt-api to 0.0.18

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -26,4 +26,4 @@ dependencies:
   version: 1.6.2
 - name: receipt-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.17
+  version: 0.0.18


### PR DESCRIPTION
chore: Promote receipt-api to version 0.0.18